### PR TITLE
fix: change cookie name into arke-console-auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:18-alpine AS base
 
-ARG PROJECT_ID
 ARG ARKE_SERVER_SSR_URL="http://host.docker.internal:4000/lib"
 ARG ARKE_SERVER_URL="http://0.0.0.0:4000/lib"
 ARG NEXTAUTH_URL="http://localhost:3100/api/auth"

--- a/README.md
+++ b/README.md
@@ -46,12 +46,11 @@ Visit the console on http://localhost:3100
 
 ## Installation with Docker
 ```bash
-docker build --build-arg PROJECT_ID=project --build-arg -t arke-console . 
+docker build -t arke-console . 
 docker run -p 3100:3100 arke-console 
 ```
 
 The build command accepts following parameters, that allows the customization of env variables:
-- `PROJECT_ID` - the name of the project
 - `ARKE_SERVER_URL` - the url of the Arke server
-- `ARKE_PROJECT` - the name of the Arke project
+- `ARKE_SERVER_SSR_URL` - the url of the Arke server for SSR
 - `NEXTAUTH_URL` - the url of the console

--- a/arke/getClient.ts
+++ b/arke/getClient.ts
@@ -20,6 +20,7 @@ import { getSession } from "next-auth/react";
 import { getToken } from "next-auth/jwt";
 import * as process from "process";
 import { getCookie } from "cookies-next";
+import { getCookieName } from "../utils/auth";
 
 const getServerUrl = () => {
   if (
@@ -46,7 +47,10 @@ export const getClient = (context?: {
       })?.toString() ?? "",
     getSession: async () => {
       if (typeof window === "undefined" && context) {
-        return getToken({ req: context?.req });
+        return getToken({
+          req: context?.req,
+          cookieName: `${getCookieName()}.session-token`,
+        });
       }
       return getSession() as Promise<TToken>;
     },

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -66,6 +66,8 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
       },
     }),
   ];
+  const useSecureCookies = process.env.NEXTAUTH_URL?.startsWith("https://");
+  const cookiePrefix = useSecureCookies ? "__Secure-" : "";
 
   return await NextAuth(req, res, {
     callbacks: {
@@ -116,5 +118,67 @@ export default async function auth(req: NextApiRequest, res: NextApiResponse) {
       newUser: "/auth/new-org", // New users will be directed here on first sign in (leave the property out if not of interest)
     },
     session: { strategy: "jwt" },
+    cookies: {
+      sessionToken: {
+        name: `${cookiePrefix}arke-console-auth.session-token`,
+        options: {
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          secure: useSecureCookies,
+        },
+      },
+      callbackUrl: {
+        name: `${cookiePrefix}arke-console-auth.callback-url`,
+        options: {
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          secure: useSecureCookies,
+        },
+      },
+      csrfToken: {
+        // Default to __Host- for CSRF token for additional protection if using useSecureCookies
+        // NB: The `__Host-` prefix is stricter than the `__Secure-` prefix.
+        name: `${
+          useSecureCookies ? "__Host-" : ""
+        }arke-console-auth.csrf-token`,
+        options: {
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          secure: useSecureCookies,
+        },
+      },
+      pkceCodeVerifier: {
+        name: `${cookiePrefix}arke-console-auth.pkce.code_verifier`,
+        options: {
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          secure: useSecureCookies,
+          maxAge: 60 * 15, // 15 minutes in seconds
+        },
+      },
+      state: {
+        name: `${cookiePrefix}arke-console-auth.state`,
+        options: {
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          secure: useSecureCookies,
+          maxAge: 60 * 15, // 15 minutes in seconds
+        },
+      },
+      nonce: {
+        name: `${cookiePrefix}arke-console-auth.nonce`,
+        options: {
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          secure: useSecureCookies,
+        },
+      },
+    },
   });
 }

--- a/server/withAuth.ts
+++ b/server/withAuth.ts
@@ -17,6 +17,7 @@
 import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
 import { getToken } from "next-auth/jwt";
 import { getClient } from "@/arke/getClient";
+import { getCookieName } from "../utils/auth";
 
 export function withAuth<
   P extends { [key: string]: unknown } = { [key: string]: unknown }
@@ -28,7 +29,10 @@ export function withAuth<
   return async function nextGetServerSidePropsHandlerWrappedWithLoggedInRedirect(
     context: GetServerSidePropsContext
   ) {
-    const session = await getToken({ req: context?.req });
+    const session = await getToken({
+      req: context?.req,
+      cookieName: `${getCookieName()}.session-token`,
+    });
     const client = getClient(context);
 
     if (!session)

--- a/server/withLoggedInRedirect.ts
+++ b/server/withLoggedInRedirect.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
-import { getSession } from 'next-auth/react';
+import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
+import { getSession } from "next-auth/react";
 
 export function withLoggedInRedirect<
   P extends { [key: string]: unknown } = { [key: string]: unknown }

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2023 Arkemis S.r.l.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 function getCookieName() {
   const secureCookie = process.env.NEXTAUTH_URL?.startsWith("https://");
   return `${secureCookie ? "__Secure-" : ""}arke-console-auth`;

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,0 +1,6 @@
+function getCookieName() {
+  const secureCookie = process.env.NEXTAUTH_URL?.startsWith("https://");
+  return `${secureCookie ? "__Secure-" : ""}arke-console-auth`;
+}
+
+export { getCookieName };


### PR DESCRIPTION
Since having `next-auth` as cookie prefix was leading to conflicts when running both the console and a project locally we changed the cookie name for the console auth from `next-auth` to `arke-console-auth`. 

Fixes #7 